### PR TITLE
Changed p.kill() to p.terminate() to allow usage on Linux - subproces…

### DIFF
--- a/ffii2avi_recursive.py
+++ b/ffii2avi_recursive.py
@@ -56,4 +56,4 @@ if __name__ == "__main__":
                 
     print('Conversion of %i files over!'%nbFiles)
     print("--- %.2f seconds elapsed ---" % (time.time() - start_time))
-    p.kill()
+    p.terminate()


### PR DESCRIPTION
Changed p.kill() to p.terminate() to allow usage on Linux - subprocess.kill() issues a SIGKILL on linux, and is an alias for subprocess.terminate() on Windows.